### PR TITLE
Create Actions workflow for build status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu:
+    name: Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Tree
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Build
+        run: |
+          mkdir build && cd build && cmake ..
+          make
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: OpenJVS3
+          path: build/bin/
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OpenJVS3
+[![Build status](https://github.com/bobbydilley/OpenJVS3/workflows/Build/badge.svg?branch=master)](https://github.com/bobbydilley/OpenJVS3/actions?query=branch%3Amaster)
 
 This is a completely new version of OpenJVS built from the JVSCore project. The aim of this revision of the software is to be stable on all hardware and linux distributions, and built in a maintainable way.
 


### PR DESCRIPTION
This is a simple workflow which just builds the project and supplies a artifact which users can download for up to 3/6 months (depending on changing policies...), and also adds a build badge on the readme for more exposure.

Again this probably isn't needed, just something nice.